### PR TITLE
Use https for JDK javadoc links.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -47,9 +47,17 @@ dependencies {
 /*
  * External javadoc links
  */
-// FIXME: For some reason, making this https causes OpenJDK 11 to fail.
-javadoc.options.links("http://docs.oracle.com/javase/7/docs/api/");
-javadoc.options.links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
-javadoc.options.links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
-javadoc.options.links("https://www.javadoc.io/doc/com.google.guava/guava/25.1-jre/");
-javadoc.options.links("https://fge.github.io/msg-simple/");
+javadoc {
+    options {
+        def currentJavaVersion = org.gradle.api.JavaVersion.current()
+        // FIXME: https://github.com/gradle/gradle/issues/11182
+        if (currentJavaVersion.compareTo(org.gradle.api.JavaVersion.VERSION_1_9) >= 0) {
+            addStringOption("-release", "7");
+        }
+        links("https://docs.oracle.com/javase/7/docs/api/");
+        links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
+        links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
+        links("https://www.javadoc.io/doc/com.google.guava/guava/25.1-jre/");
+        links("https://java-json-tools.github.io/msg-simple/");
+    }
+}


### PR DESCRIPTION
Conditionally adds a `--release=7` flag to tell javadoc the source compatibility. This inhibits javadoc in later JDKs erroring out expecting modules when there are none.

See java-json-tools/btf/issues/7.

Also fixes the reference to be to java-json-tools/msg-simple.