### PR TITLE
Bump Guava to 28.1-android.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -30,7 +30,7 @@ targetCompatibility = JavaVersion.VERSION_1_7; // defaults to sourceCompatibilit
  */
 
 dependencies {
-    compile(group: "com.google.guava", name: "guava", version: "25.1-android");
+    compile(group: "com.google.guava", name: "guava", version: "28.1-android");
     compile(group: "com.github.fge", name: "msg-simple", version: "1.1");
     compile(group: "com.google.code.findbugs", name: "jsr305",
         version: "2.0.1");
@@ -57,7 +57,7 @@ javadoc {
         links("https://docs.oracle.com/javase/7/docs/api/");
         links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
         links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
-        links("https://www.javadoc.io/doc/com.google.guava/guava/25.1-android/");
+        links("https://www.javadoc.io/doc/com.google.guava/guava/28.1-android/");
         links("https://java-json-tools.github.io/msg-simple/");
     }
 }


### PR DESCRIPTION
Now that we're using the android track with support for Java 7, we shouldn't run into missing symbols errors. See java-json-tools/json-schema-core/issues/59.